### PR TITLE
デッキに入っているカードに、ポケモンのグッズの外部キーを設定しました。

### DIFF
--- a/app/models/card_in_deck.rb
+++ b/app/models/card_in_deck.rb
@@ -1,0 +1,2 @@
+class CardInDeck < ApplicationRecord
+end

--- a/db/migrate/20240127080207_create_card_in_decks.rb
+++ b/db/migrate/20240127080207_create_card_in_decks.rb
@@ -1,0 +1,8 @@
+class CreateCardInDecks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :card_in_decks do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240127081249_add_pokemon_no_items_to_card_in_deck.rb
+++ b/db/migrate/20240127081249_add_pokemon_no_items_to_card_in_deck.rb
@@ -1,0 +1,5 @@
+class AddPokemonNoItemsToCardInDeck < ActiveRecord::Migration[7.0]
+  def change
+    add_column :card_in_decks, :card_in_deck_id, :integer
+  end
+end

--- a/db/migrate/20240127081249_add_pokemon_no_items_to_card_in_deck.rb
+++ b/db/migrate/20240127081249_add_pokemon_no_items_to_card_in_deck.rb
@@ -1,5 +1,5 @@
 class AddPokemonNoItemsToCardInDeck < ActiveRecord::Migration[7.0]
   def change
-    add_column :card_in_decks, :card_in_deck_id, :integer
+    add_reference :card_in_decks, :pokemon_no_items, foreign_key: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,7 +14,8 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_27_081249) do
   create_table "card_in_decks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "card_in_deck_id"
+    t.integer "pokemon_no_items_id"
+    t.index ["pokemon_no_items_id"], name: "index_card_in_decks_on_pokemon_no_items_id"
   end
 
   create_table "decks", force: :cascade do |t|
@@ -74,4 +75,5 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_27_081249) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "card_in_decks", "pokemon_no_items", column: "pokemon_no_items_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_27_080207) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_27_081249) do
   create_table "card_in_decks", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "card_in_deck_id"
   end
 
   create_table "decks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_01_20_083937) do
+ActiveRecord::Schema[7.0].define(version: 2024_01_27_080207) do
+  create_table "card_in_decks", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "decks", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false

--- a/test/fixtures/card_in_decks.yml
+++ b/test/fixtures/card_in_decks.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/card_in_deck_test.rb
+++ b/test/models/card_in_deck_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class CardInDeckTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
■外部キー設定手順(後から追加する方法)

①テーブルを作成(カラムに何も入れずテーブルだけ作成)
```bash
$ rails generate model Card_in_deck 
```
②`$rails db:migrate`でテーブルを作成

ーーーーーーーーーーーFKの設定ーーーーーーーーーーー
③作成したテーブルにカラムを追加する
```bash
$ rails generate migrate AddPokemonNoItemsToCardInDeck
```
④`db/migrate/~~~~.rb`ファイルに異kのように外部キーの設定をする
```ruby
class AddPokemonNoItemsToCardInDeck < ActiveRecord::Migration[7.0]
  def change
    add_reference :card_in_decks, :pokemon_no_items, foreign_key: true
  end
end
```
※もし上記を書く際間違えた場合は、書き直して`db/schema.rb`を削除、`rails db:reset`実行、`rails db:migrate`を実行
※`add_reference`の部分は`add_column`になっていると思うので変更し、２つ目のカラム名もテーブル名に変更する。
※`type: integer`はデフォルトでいいので書かなくて良い。
※また、IDがNULLになって欲しくない場合は、`null: false`を`foreign_key: true, `の後に追加。
→テーブルのschemaにnut nullを追加する設定。
⑤`$ rails db:migrate`
⑥`sqlite> .schema card_in_decks`でカラムが作成されたか確認。
```sql
sqlite> .schema card_in_decks
CREATE TABLE IF NOT EXISTS "card_in_decks" (
"id" integer NOT NULL PRIMARY KEY, 
"created_at" datetime(6) NOT NULL, 
"updated_at" datetime(6) NOT NULL, 
"pokemon_no_items_id" integer DEFAULT NULL, 
CONSTRAINT "fk_rails_e40888835a"FOREIGN KEY ("pokemon_no_items_id")  REFERENCES "pokemon_no_items" ("id")
Us
CREATE INDEX "index_card_in_decks_on_pokemon_no_items_id" ON "card_in_decks" ("pokemon_no_items_id");
```
※↑見やすいように改行した！
外部キーが作成されているのでOK