### PR TITLE
apps/models/skill.rbで外部キーの設定を変更しました。

### DIFF
--- a/app/models/skill.rb
+++ b/app/models/skill.rb
@@ -1,4 +1,4 @@
 class Skill < ApplicationRecord
-  has_many :pokemons, foreign_key: :skill1_id
-  has_many :pokemons, foreign_key: :skill2_id
+  has_many :pokemons1, class_name: 'Pokemon', foreign_key: :skill1_id
+  has_many :pokemons2, class_name: 'Pokemon', foreign_key: :skill2_id
 end


### PR DESCRIPTION
**①skillsテーブルから外部キーを通じてポケモンの情報を取得できるか「rails console」で確認。**
```
irb(main):003> a.pokemons
=> []
irb(main):004> a = Skill.find_by(name: "ひっさつまえば")
  Skill Load (0.6ms)  SELECT "skills".* FROM "skills" WHERE "skills"."name" = ? LIMIT ?  [["name", "ひっさつまえば"], ["LIMIT", 1]]
=> 
#<Skill:0x0000000105e651f8
...
irb(main):005> a.pokemons
  Pokemon Load (0.1ms)  SELECT "pokemons".* FROM "pokemons" WHERE "pokemons"."skill2_id" = ?  [["skill2_id", 3]]
=> []
```
→skillsテーブルに(name:"ひっさつまえば")を持つデータに属するデータをpokemonsテーブルから取得できるようにしたいが空の情報が出力されてしまう。上記でpokemonsテーブルから「ビッパ」を取得できるようにしたい。
　pokemonsテーブルのskill1_idのカラムを取得したいが、skill2_idが3のpokemonsテーブルの情報を取得しているため結果が空となってしまう。

**②変更前のファイルの内容**
【app/models/skill.rb】
```ruby
class Skill < ApplicationRecord
  has_many :pokemons, foreign_key: :skill1_id
  has_many :pokemons, foreign_key: :skill2_id
end
```
→Skillからskill1_id、skill2_idどちらも「pokemons」と同じ名前が付いていることが原因で、後ろのskill2_idの情報が取得されてしまっている。

**③別名を設定する。変更後のファイル内容。**
【app/models/skill.rb】
```ruby
class Skill < ApplicationRecord
  has_many :pokemons1, class_name: 'Pokemon', foreign_key: :skill1_id
  has_many :pokemons2, class_name: 'Pokemon', foreign_key: :skill2_id
end
```
→pokemons1、pokemons2だけでは有効なモデルを見つけることができず、エラーが出力されるため、class_nameの記載も必合わせて記入。

**④skillsテーブルからpokemonsの情報が取得できるか「rails console」で再度確認。**
```
irb(main):002> a = Skill.find_by(name: "ひっさつまえば")
  Skill Load (0.1ms)  SELECT "skills".* FROM "skills" WHERE "skills"."name" = ? LIMIT ?  [["name", "ひっさつまえば"], ["LIMIT", 1]]
=> 
#<Skill:0x0000000109f74090
irb(main):002> a.pokemons1
  Pokemon Load (0.1ms)  SELECT "pokemons".* FROM "pokemons" WHERE "pokemons"."skill1_id" = ?  [["skill1_id", 3]]
=> 
[#<Pokemon:0x0000000105fbe978
  id: 1,
  sinka: "たね",
  name: "ビッパ",
  special: nil,
  hp: 60,
  zokusei: "無色",
  tokusei_id: 2,
  skill1_id: 3,
  skill2_id: nil,
  created_at: Sat, 03 Feb 2024 07:00:46.687778000 UTC +00:00,
  updated_at: Sat, 03 Feb 2024 07:00:46.687778000 UTC +00:00>]
irb(main):003> a.pokemons2
  Pokemon Load (0.1ms)  SELECT "pokemons".* FROM "pokemons" WHERE "pokemons"."skill2_id" = ?  [["skill2_id", 3]]
=> []
```
→pokemons1を指定することで、skill1_idに設定している情報をpokemonsテーブルから取得できた。
pokemons2を指定すると、ひっさつまえばはpokemonsテーブルのskill2_idに設定されていないため、空が帰ってくる。

ご確認お願いします。